### PR TITLE
Se implementó CRUD para la entidad Usuarios

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
+        "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/typeorm": "^11.0.0",
         "mysql2": "^3.14.1",
@@ -2536,6 +2537,26 @@
           "optional": true
         },
         "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/typeorm": "^11.0.0",
     "mysql2": "^3.14.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { UsuariosModule } from './usuarios/usuarios.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [TypeOrmModule.forRoot({
+  imports: [UsuariosModule, TypeOrmModule.forRoot({
     type: 'mysql',
     host: 'localhost',
     port: 3306,

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/backend/src/usuarios/dto/create-usuario.dto.ts
+++ b/backend/src/usuarios/dto/create-usuario.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, IsEmail, MinLength, IsOptional, IsIn,} from 'class-validator';
+
+export class CrearUsuarioDto {
+  @IsString({ message: 'El nombre debe ser un texto.' })
+  @MinLength(3, { message: 'El nombre debe tener al menos 3 caracteres.' })
+  nombre: string;
+
+  @IsEmail({}, { message: 'El formato del email no es válido.' })
+  email: string;
+
+  @IsString()
+  @MinLength(6, { message: 'La contraseña debe tener al menos 6 caracteres.' })
+  password: string;
+
+  @IsOptional()
+  @IsIn(['admin', 'editor', 'viewer'], { message: 'El rol no es válido.' })
+  rol?: string;
+}

--- a/backend/src/usuarios/dto/update-usuario.dto.ts
+++ b/backend/src/usuarios/dto/update-usuario.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CrearUsuarioDto } from './create-usuario.dto';
+
+export class ActualizarUsuarioDto extends PartialType(CrearUsuarioDto) {}

--- a/backend/src/usuarios/entities/usuario.entity.ts
+++ b/backend/src/usuarios/entities/usuario.entity.ts
@@ -1,0 +1,22 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity({ name: 'usuarios'})
+export class Usuario {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ length: 100})
+    nombre: string;
+
+    @Column({ length: 100, unique: true})
+    email: string;
+
+    @Column()
+    password: string;
+
+    @Column({ type: 'enum', enum: ['admin', 'editor', 'viewer'], default: 'viewer'})
+    rol: string;
+
+    @CreateDateColumn({ name: 'creado_en', type: 'timestamp'})
+    creadoEn: Date;
+}

--- a/backend/src/usuarios/usuarios.controller.ts
+++ b/backend/src/usuarios/usuarios.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, HttpCode, HttpStatus, ParseIntPipe } from '@nestjs/common';
+import { UsuariosService } from './usuarios.service';
+import { CrearUsuarioDto } from './dto/create-usuario.dto';
+import { ActualizarUsuarioDto } from './dto/update-usuario.dto';
+
+@Controller('usuarios')
+export class UsuariosController {
+  constructor(private readonly usuariosService: UsuariosService) {}
+
+  @Post()
+  crearUsuario(@Body() crearUsuarioDto: CrearUsuarioDto) {
+    return this.usuariosService.crearUsuario(crearUsuarioDto);
+  }
+
+  @Get()
+  obtenerTodosLosUsuarios() {
+    return this.usuariosService.obtenerTodosLosUsuarios();
+  }
+
+  @Get(':id')
+  obtenerUsuarioPorId(@Param('id', ParseIntPipe) id: number) {
+    return this.usuariosService.obtenerUsuarioPorId(id);
+  }
+
+  @Patch(':id')
+  actualizarUsuario(@Param('id', ParseIntPipe) id: number, @Body() actualizarUsuarioDto: ActualizarUsuarioDto) {
+    return this.usuariosService.actualizarUsuario(id, actualizarUsuarioDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  eliminarUsuario(@Param('id', ParseIntPipe) id: number) {
+    return this.usuariosService.eliminarUsuario(id);
+  }
+}

--- a/backend/src/usuarios/usuarios.module.ts
+++ b/backend/src/usuarios/usuarios.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { UsuariosService } from './usuarios.service';
+import { UsuariosController } from './usuarios.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Usuario } from './entities/usuario.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Usuario])],
+  controllers: [UsuariosController],
+  providers: [UsuariosService],
+})
+export class UsuariosModule {}

--- a/backend/src/usuarios/usuarios.service.ts
+++ b/backend/src/usuarios/usuarios.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CrearUsuarioDto } from './dto/create-usuario.dto';
+import { ActualizarUsuarioDto } from './dto/update-usuario.dto';
+import { Usuario } from './entities/usuario.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class UsuariosService {
+
+  constructor(
+    @InjectRepository(Usuario)
+    private readonly usuarioRepository: Repository<Usuario>,
+  ) {}
+
+  async crearUsuario(crearUsuarioDto: CrearUsuarioDto): Promise <Usuario> {
+    const nuevoUsuario = this.usuarioRepository.create(crearUsuarioDto);
+    return this.usuarioRepository.save(nuevoUsuario);
+  }
+
+  async obtenerTodosLosUsuarios(): Promise<Usuario[]> {
+    return this.usuarioRepository.find();
+  }
+
+  async obtenerUsuarioPorId(id: number): Promise <Usuario> {
+    const usuario = await this.usuarioRepository.findOne({ where: {id}});
+    if (!usuario){
+      throw new NotFoundException(`Usuario con ID "${id}" no encontrado.`);
+    }
+    return usuario;
+  }
+
+  async actualizarUsuario(id: number, actualizarUsuarioDto: ActualizarUsuarioDto): Promise<Usuario> {
+    const usuario = await this.usuarioRepository.preload({
+      id: id,
+      ...actualizarUsuarioDto,
+    });
+    if (!usuario){
+      throw new NotFoundException(`No se puede actualizar. Usuario con ID "${id}" no encontrado.`);
+    }
+    return this.usuarioRepository.save(usuario);
+  }
+
+  async eliminarUsuario(id: number): Promise<void> {
+    const usuario = await this.obtenerUsuarioPorId(id);
+    await this.usuarioRepository.remove(usuario);
+  }
+}


### PR DESCRIPTION
Se ha implementado la lógica completa para las operaciones CRUD para los **usuarios**.

- Todos los endpoints en el controlador (`/usuarios`) están funcionales y han sido probados con Postman.
- El servicio (`UsersService`) contiene la lógica de negocio para interactuar con la base de datos a través de TypeORM.